### PR TITLE
updated docs link and code snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-[iearn.finance](https://docs.iearn.finance)
+[docs.yearn.finance](https://docs.yearn.finance/)
 
 # Smart Contract Interface
 
@@ -8,12 +8,11 @@
 | -- | -- | -- |
 | Uniswap_ETH_CDAIZAP | [JSON](https://github.com/iearn-finance/zap/blob/master/build/contracts/UniSwap_ETH_CDAIZap.json) | [0xB82674CfA16bb28D9b70bEC830fF24BAEC6B1337](https://etherscan.io/address/0xb82674cfa16bb28d9b70bec830ff24baec6b1337#code) |
 
-
 ## ZAP Interface
 
-{% tabs %}
-{% tab title="IUniSwap_ETH_CDAIZap.sol" %}
-```javascript
+### IUniSwap_ETH_CDAIZap.sol
+
+```solidity
 // Solidity Interface
 
 interface IUniSwap_ETH_CDAIZap {
@@ -34,5 +33,3 @@ interface IUniSwap_ETH_CDAIZap {
     function getSharesReturn(address _UniSwapExchangeContractAddress, IERC20 _ERC20TokenAddress, uint _ethValue) external view returns (uint);
 }
 ```
-{% endtab %}
-{% endtabs %}


### PR DESCRIPTION
Hi,

So I have been trying to learn more about yearn and its ecosystem when I came across this repo. Then I noticed that the current link to the documentation in the README (https://docs.iearn.finance) seems to be out of date, and from what I understand should now point to https://docs.yearn.finance/ instead. Thought this might help others in similar situation to me.

Also, I have updated the language tag of the code snippet in the ZAP Interface section of the README (to Solidity, which I believe GitHub markdown supports) as well as removed what seems to be leftover template code (i.e. `{% endtab %}{% endtabs %}`) ? 

I apologize if I misunderstand something or if you guy aren't accepting pull requests.

As an aside, let me know if you need any help with documentation or anything at all. Would absolutely love to help in any way I can!